### PR TITLE
kebab-case の slug 対応

### DIFF
--- a/src/nextjs/parsePagesDir.ts
+++ b/src/nextjs/parsePagesDir.ts
@@ -16,7 +16,14 @@ export const createMethods = (
     importName ? `query${importName.startsWith('Optional') ? '?' : ''}: ${importName}, ` : ''
   }hash?: string }) => ({ pathname: '${pathname}' as const${
     slugs.length
-      ? `, query: { ${slugs.join(', ')}${
+      ? `, query: { ${slugs
+          .map(slug => {
+            if (slug.indexOf('-') >= 0) {
+              return `'${slug}': ${slug.replace(/-/g, '_')}`
+            }
+            return slug
+          })
+          .join(', ')}${
           importName ? `, ...url${importName.startsWith('Query') ? '' : '?'}.query` : ''
         } }`
       : importName
@@ -77,7 +84,9 @@ export const parsePagesDir = (
 
         if (basename.startsWith('[') && basename.endsWith(']')) {
           const slug = basename.replace(/[.[\]]/g, '')
-          valFn = `${indent}${`_${slug}`}: (${slug}${basename.startsWith('[[') ? '?' : ''}: ${
+          valFn = `${indent}"${`_${slug}`}": (${slug.replace(/-/g, '_')}${
+            basename.startsWith('[[') ? '?' : ''
+          }: ${
             /\[\./.test(basename) ? 'string[]' : 'string | number'
           }) => ({\n<% next %>\n${indent}})`
           newSlugs.push(slug)


### PR DESCRIPTION
# kebab-case の slug 対応

<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [x] Features
  - ~~resolves #<!-- Please add issue number -->~~
  - kebab-case のクエリに対応する。

## Changes

### `src/nextjs/parsePagesDir.ts`

- [x] `createMethods`
  - query 用の slug を kebab-case から snake_case に変更
  - query の値を slug が kebab-case の場合 `key: value` に変更
- [x] `parsePagesDir` / `createPathObjString`
  - slug の path を `"` により wrap する。
  - slug の args を snake_case に変更

## Additional context

<details>
<summary>kebab-case query trouble</summary>

### ケバブケースのクエリの問題

Next.js などでパスを `/test-test/test-test-1/[test-id]` などとすると出力されるファイルに問題が発生する。

```ts
// $path.ts
export const pagesPath = {
  "test_test": {
    "test_test_1": {
      _test-id: (test-id: string | number) => ({
        $url: (url?: { hash?: string }) => ({ pathname: '/test-test/test-test-1/[test-id]' as const, query:  test-id }, hash: url?.hash })
```

問題として

- クエリに該当するパスにケバブケースを使用すると、その部分のキーがそのままケバブケースで定義され、\
  クォーテーションなどで囲まれもしないためシンタックスエラーとなる。
  - クエリでない部分のケバブケースはスネークケースに変換される。
  - ケバブケースを維持しているのはユーザー定義のクエリとの齟齬を発生させないためか？
    - 「 `test-id=` のクエリを想定していたのに勝手に `test_id=` になった 」

対応案として

- クエリ部分は `スネークケース` か `キャメルケース` を徹底する。

#### ケバブケースのクエリの問題発生箇所

以下ファイルにて `$path.ts` の出力部分の処理を行っている。

- `src/nextjs/parsePagesDir.ts`

`slug` のケバブケースの問題は以下の対応が考えられる。

- `_${slug}` の部分を `"` で囲う.
- `: (${slug}` の部分が引数となっているため `: (${slug.replace(/-/g, '_')}` に変更
  - `createMethods` の部分と引数、キーを同期させる必要がある。

```ts
        if (basename.startsWith('[') && basename.endsWith(']')) {
          const slug = basename.replace(/[.[\]]/g, '')
          valFn = `${indent}${`_${slug}`}: (${slug}${basename.startsWith('[[') ? '?' : ''}: ${
```

`createMethods` での対応

- 上記でスネークケースにした引数と `query: {}` 配下の構造を同期させる。
  - `test-id` -> `test_id`
    - `query: { test_id }` -> `query: { 'test-id': test_id }`

```ts
export const createMethods = (
  indent: string,
  importName: string | undefined,
  slugs: Slugs,
  pathname: string
) =>
  `${indent}  $url: (url${importName?.startsWith("Query") ? "" : "?"}: { ${
    importName ? `query${importName.startsWith("Optional") ? "?" : ""}: ${importName}, ` : ""
  }hash?: string }) => ({ pathname: '${pathname}' as const${
    slugs.length
      ? // この部分において `query: {}` 内部要素が生成されるが、ケバブケースであると問題が発生
        `, query: { ${slugs.join(", ")}${
          importName ? `, ...url${importName.startsWith("Query") ? "" : "?"}.query` : ""
        } }`
      : importName
      ? `, query: url${importName.startsWith("Query") ? "" : "?"}.query`
      : ""
  }, hash: url${importName?.startsWith("Query") ? "" : "?"}.hash })`
```

</details>

## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
